### PR TITLE
Update font colors to match all other cells

### DIFF
--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -317,12 +317,12 @@ export default class AstraTable extends ClassifiedElement {
 
     if (theme == Theme.dark) {
       document.documentElement.style.setProperty('--ob-background-color', '#0A0A0A')
-      document.documentElement.style.setProperty('--ob-text-color', '#D4D4D4')
+      document.documentElement.style.setProperty('--ob-text-color', '#FFFFFF')
       document.documentElement.style.setProperty('--ob-border-color', '#262626')
       document.documentElement.style.setProperty('--ob-null-text-color', '#959497')
     } else {
       document.documentElement.style.setProperty('--ob-background-color', '#FAFAFA')
-      document.documentElement.style.setProperty('--ob-text-color', '#525252')
+      document.documentElement.style.setProperty('--ob-text-color', '#000000')
       document.documentElement.style.setProperty('--ob-border-color', '#E5E5E5')
       document.documentElement.style.setProperty('--ob-null-text-color', '#D0D0D0')
     }


### PR DESCRIPTION
![image](https://github.com/outerbase/astra-ui/assets/36182383/79667c79-488e-4a38-8d3c-15c1b9a0ec0e)

Font colors on plugins do not currently match what is in cells.