### PR TITLE
Better support for plugins based on permissioning

### DIFF
--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -5,27 +5,27 @@ import { ifDefined } from 'lit/directives/if-defined.js'
 import { repeat } from 'lit/directives/repeat.js'
 import arrayToObject from '../../lib/array-to-object.js'
 import {
-  ColumnAddedEvent,
-  ColumnHiddenEvent,
-  ColumnPluginDeactivatedEvent,
-  ColumnRemovedEvent,
-  MenuOpenEvent,
-  ResizeEvent,
-  RowAddedEvent,
-  RowRemovedEvent,
-  RowSelectedEvent,
+    ColumnAddedEvent,
+    ColumnHiddenEvent,
+    ColumnPluginDeactivatedEvent,
+    ColumnRemovedEvent,
+    MenuOpenEvent,
+    ResizeEvent,
+    RowAddedEvent,
+    RowRemovedEvent,
+    RowSelectedEvent,
 } from '../../lib/events.js'
 import {
-  ColumnStatus,
-  DBType,
-  Theme,
-  type ColumnPlugin,
-  type Columns,
-  type HeaderMenuOptions,
-  type PluginWorkspaceInstallationId,
-  type RowAsRecord,
-  type Schema,
-  type TableColumn,
+    ColumnStatus,
+    DBType,
+    Theme,
+    type ColumnPlugin,
+    type Columns,
+    type HeaderMenuOptions,
+    type PluginWorkspaceInstallationId,
+    type RowAsRecord,
+    type Schema,
+    type TableColumn,
 } from '../../types.js'
 import { ClassifiedElement } from '../classified-element.js'
 
@@ -387,6 +387,7 @@ export default class AstraTable extends ClassifiedElement {
                       .position=${{ row: id, column: name }}
                       .value=${values[name]}
                       .originalValue=${originalValues[name]}
+                      .column=${name}
                       width="${this.widthForColumnType(name, this.columnWidthOffsets[name])}px"
                       theme=${this.theme}
                       type=${this.columnTypes?.[name]}

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -5,27 +5,27 @@ import { ifDefined } from 'lit/directives/if-defined.js'
 import { repeat } from 'lit/directives/repeat.js'
 import arrayToObject from '../../lib/array-to-object.js'
 import {
-    ColumnAddedEvent,
-    ColumnHiddenEvent,
-    ColumnPluginDeactivatedEvent,
-    ColumnRemovedEvent,
-    MenuOpenEvent,
-    ResizeEvent,
-    RowAddedEvent,
-    RowRemovedEvent,
-    RowSelectedEvent,
+  ColumnAddedEvent,
+  ColumnHiddenEvent,
+  ColumnPluginDeactivatedEvent,
+  ColumnRemovedEvent,
+  MenuOpenEvent,
+  ResizeEvent,
+  RowAddedEvent,
+  RowRemovedEvent,
+  RowSelectedEvent,
 } from '../../lib/events.js'
 import {
-    ColumnStatus,
-    DBType,
-    Theme,
-    type ColumnPlugin,
-    type Columns,
-    type HeaderMenuOptions,
-    type PluginWorkspaceInstallationId,
-    type RowAsRecord,
-    type Schema,
-    type TableColumn,
+  ColumnStatus,
+  DBType,
+  PluginWorkspaceInstallationId,
+  Theme,
+  type ColumnPlugin,
+  type Columns,
+  type HeaderMenuOptions,
+  type RowAsRecord,
+  type Schema,
+  type TableColumn,
 } from '../../types.js'
 import { ClassifiedElement } from '../classified-element.js'
 
@@ -69,6 +69,11 @@ export default class AstraTable extends ClassifiedElement {
 
   @property({ attribute: 'installed-plugins', type: Array })
   public installedPlugins?: Record<string, PluginWorkspaceInstallationId | undefined>
+
+  //// BRAYDEN DID THIS
+  @property({ attribute: 'real-installed-plugins', type: Array })
+  public realInstalledPlugins?: Array<any>
+  //// END BRAYDEN
 
   @property({ attribute: 'non-interactive', type: Boolean })
   public isNonInteractive = false
@@ -379,6 +384,14 @@ export default class AstraTable extends ClassifiedElement {
                   )
                   const defaultPlugin = this.plugins?.find(({ id }) => id === this.installedPlugins?.[name]?.plugin_installation_id)
                   const plugin = installedPlugin ?? defaultPlugin
+
+                  const realInstallation = this.realInstalledPlugins?.find(
+                    ({ plugin_workspace_id }) => plugin?.pluginWorkspaceId === plugin_workspace_id
+                  )
+
+                  if (plugin && realInstallation?.config) {
+                    plugin.config = JSON.stringify(realInstallation?.config)
+                  }
 
                   return html`
                     <!-- TODO @johnny remove separate-cells and instead rely on css variables to suppress borders -->

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -18,11 +18,11 @@ import {
 import {
   ColumnStatus,
   DBType,
-  PluginWorkspaceInstallationId,
   Theme,
   type ColumnPlugin,
   type Columns,
   type HeaderMenuOptions,
+  type PluginWorkspaceInstallationId,
   type RowAsRecord,
   type Schema,
   type TableColumn,
@@ -70,10 +70,9 @@ export default class AstraTable extends ClassifiedElement {
   @property({ attribute: 'installed-plugins', type: Array })
   public installedPlugins?: Record<string, PluginWorkspaceInstallationId | undefined>
 
-  //// BRAYDEN DID THIS
+  // @Brayden – this property represents the really array of installed plugins
   @property({ attribute: 'real-installed-plugins', type: Array })
   public realInstalledPlugins?: Array<any>
-  //// END BRAYDEN
 
   @property({ attribute: 'non-interactive', type: Boolean })
   public isNonInteractive = false

--- a/src/components/table/td.ts
+++ b/src/components/table/td.ts
@@ -268,7 +268,7 @@ export class TableData extends MutableElement {
   @property({ attribute: 'hide-dirt', type: Boolean })
   public hideDirt = false
 
-  @property({ attribute: 'plugin', type: String })
+  @property({ attribute: 'plugin', type: Object })
   public plugin?: ColumnPlugin
 
   @property({ attribute: 'is-displaying-plugin-editor', type: Boolean })
@@ -313,8 +313,10 @@ export class TableData extends MutableElement {
       // TODO update our value to match the one from the editor
     } else if (eventName === PluginEvent.onCancelEdit) {
       this.isDisplayingPluginEditor = false
+      delete this._interstitialValue
     } else if (eventName === PluginEvent.updateCell) {
       this._interstitialValue = value
+      this.value = value
     }
   }
 

--- a/src/components/table/td.ts
+++ b/src/components/table/td.ts
@@ -258,7 +258,7 @@ export class TableData extends MutableElement {
   @property({ attribute: 'row', type: Number })
   public row = undefined
 
-  @property({ attribute: 'column', type: Number })
+  @property({ attribute: 'column', type: String })
   public column = undefined
 
   @property({ attribute: 'hide-dirt', type: Boolean })
@@ -434,7 +434,7 @@ export class TableData extends MutableElement {
               // possible future migration
               'astra-plugin-cell',
               'astra-plugin-editor'
-            )} cellvalue='${editorValue}' configuration='${config}' ${this.pluginAttributes}></${tagName}>`
+            )} cellvalue='${editorValue}' columnName='${this.column}' configuration='${config}' ${this.pluginAttributes}></${tagName}>`
         )
       }
     } else {

--- a/src/components/table/td.ts
+++ b/src/components/table/td.ts
@@ -28,6 +28,10 @@ const RW_OPTIONS = [
 
 const R_OPTIONS = [{ label: 'Copy', value: 'copy' }]
 
+if (customElements.get('astra-td')) {
+  // System has already registered `astra-td`
+}
+
 // tl;dr <td/>, table-cell
 @customElement('astra-td')
 export class TableData extends MutableElement {
@@ -423,7 +427,9 @@ export class TableData extends MutableElement {
 
     if (this.plugin) {
       const { config, tagName } = this.plugin
-      const pluginAsString = unsafeHTML(`<${tagName} cellvalue='${value}' configuration='${config}' ${this.pluginAttributes}></${tagName}>`)
+      const pluginAsString = unsafeHTML(
+        `<${tagName} cellvalue='${value}' columnName='${this.column}' configuration='${config}' ${this.pluginAttributes}></${tagName}>`
+      )
       cellContents = html`${pluginAsString}`
 
       if (this.isDisplayingPluginEditor) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,7 +120,7 @@ export type HeaderMenuOptions = Array<{
 
 export type ColumnPlugin = {
   columnName: string
-  config: string
+  config: any
   displayName: string
   metadata: string
   id: string
@@ -133,6 +133,7 @@ export type PluginWorkspaceInstallationId = {
   plugin_workspace_id: string
   plugin_installation_id: string
   isDefaultPlugin?: boolean
+  config?: any
   supportingAttributes: string
 }
 


### PR DESCRIPTION
Currently plugins receive more information than they might be designated to receive

- [x] Restrict the amount of data passed into the plugin based on permissions
- [X] Pass the `columnName` to the plugin so it can know what the value it holds exists for
- [X] Do not register the `astra-td` component if it is already registered