### PR TITLE
truncate column header names

### DIFF
--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -361,9 +361,9 @@ export class TH extends MutableElement {
           })} @blur=${this.onBlur}></input>`
         : this.hasMenu
           ? html`<astra-th-menu theme=${this.theme} .options=${options} @menu-selection=${this.onMenuSelection}
-              ><span class="font-normal">${this.value}</span></astra-th-menu
+              ><span class="font-normal truncate">${this.value}</span></astra-th-menu
             >`
-          : html`<span class="font-normal">${this.value}</span>`
+          : html`<span class="font-normal truncate">${this.value}</span>`
 
       return this.withResizer
         ? html`<span class=${classMap(resultContainerClasses)}


### PR DESCRIPTION
<img width="1392" alt="image" src="https://github.com/outerbase/astra-ui/assets/368767/cf3c5255-068e-46be-a9bf-94aa915b87ed">

> Table column names too long hide chevron
https://linear.app/outerbase/issue/OUT-82/table-column-names-too-long-hide-chevron