### PR TITLE
resolve issue with pasting into a new row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",

--- a/src/components/mutable-element.ts
+++ b/src/components/mutable-element.ts
@@ -138,10 +138,10 @@ export class MutableElement extends ClassifiedElement {
         // setTimeout(this.dispatchChangedEvent.bind(this), 0) // unnecessary with the initial conditional check?
         this.dispatchChangedEvent()
       }
-
-      // allow change event on next change
-      this._didSetInitialValue = true
     }
+
+    // allow change event on next change
+    this._didSetInitialValue = true
   }
 
   protected _originalValue?: Serializable


### PR DESCRIPTION
tl;dr when a component is first rendered, this handler is triggered with it's value being set. but when adding new rows, the before/after is undefined, meaning this block of code doesn't run ```if (oldValue !== newValue) {```, and so the super important conditional code doesn't execute

typing into a cell instead of pasting triggers multiple updates and thus the subsequent keystrokes mask the bug. but pasting, even over and over, since it's the same value being repasted, means this conditional doesn't run

logic amirite

https://linear.app/outerbase/issue/OUT-103/cannot-save-copied-data-in-my-table