### PR TITLE
hide/show columns when hidden-column property changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -220,8 +220,6 @@ export default class AstraTable extends ClassifiedElement {
 
   protected _onColumnHidden({ name }: ColumnHiddenEvent) {
     this.hiddenColumnNames.push(name)
-    this.requestUpdate('columns')
-    this.updateVisibleColumns()
   }
 
   // TODO @johnny 'Select All' is firing this once for each row instead of just once
@@ -522,6 +520,10 @@ export default class AstraTable extends ClassifiedElement {
       })
 
       this.updateTableView()
+    }
+
+    if (changedProperties.has('hiddenColumnNames')) {
+      this.updateVisibleColumns()
     }
   }
 

--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -209,7 +209,7 @@ export class TH extends MutableElement {
   }
 
   public hideColumn() {
-    if (!this.originalValue) throw new Error('missing OG value')
+    if (!this.originalValue) throw new Error('missing column name (i.e. this.originalValue)')
 
     this.dispatchEvent(
       new ColumnHiddenEvent({


### PR DESCRIPTION
previously only processed when the hiding action came from within the table instead of from the underlying property changes

https://linear.app/outerbase/issue/OUT-81/hiding-column-doesnt-remove-the-column-from-being-displayed