### PR TITLE
stop choosing which sort to apply when a column header is clicked

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",

--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -190,7 +190,7 @@ export class TH extends MutableElement {
       this.dispatchEvent(
         new ColumnUpdatedEvent({
           name,
-          data: { action: 'sort:alphabetical:ascending' },
+          data: { action: 'sort' },
         })
       )
     } else {


### PR DESCRIPTION
allowing dashboard to cycle through ascending, descending, and unapplying sort
this does not remove the ability to explicitly choose ascending/descending from the menu -- that continues to function explicitly