### PR TITLE
improve react + typescript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ We've also packaged Astra for React:
 ```js
 import React from 'react'
 import Astra from '@outerbase/astra-ui/react'
-const { Select, Text, Input, Card, Button } = Astra(React)
+const { Select, Text, Input, Card, Button, ScrollArea, Table } = Astra(React)
 
 function ArbitraryComponent() {
   return <Button>Click me</Button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,17 @@ import Text from './components/text.js'
 
 // export * as Types from './types'
 export { Button, Card, Input, ScrollArea, Select, Table, Text }
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'astra-scroll-area': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
+      'astra-table': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
+      'astra-button': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
+      'astra-card': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
+      'astra-input': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
+      'astra-text': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
+      'astra-select': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
+    }
+  }
+}

--- a/src/react.ts
+++ b/src/react.ts
@@ -5,7 +5,9 @@ import { createComponent } from '@lit/react'
 import AstraButton from './components/button.js'
 import AstraCard from './components/card.js'
 import AstraInput from './components/input.js'
+import AstraScrollArea from './components/scroll-area.js'
 import AstraSelect from './components/select.js'
+import AstraTable from './components/table/index.js'
 import AstraText from './components/text.js'
 
 export default function LitComponents(React: any) {
@@ -33,6 +35,16 @@ export default function LitComponents(React: any) {
     Select: createComponent({
       tagName: 'astra-select',
       elementClass: AstraSelect,
+      react: React,
+    }),
+    ScrollArea: createComponent({
+      tagName: 'astra-scroll-area',
+      elementClass: AstraScrollArea,
+      react: React,
+    }),
+    Table: createComponent({
+      tagName: 'astra-table',
+      elementClass: AstraTable,
       react: React,
     }),
   }


### PR DESCRIPTION
v0.0.21

resolves dashboard from complaining if you try to `<astra-scroll-area>stuff</...>` directly
but also now exports the React-able component so I'll be doing this:

```tsx
import AstraReact from '@outerbase/astra-ui/react'
const { ScrollArea } = AstraReact(React)
```
```tsx
<ScrollArea>...</ScrollArea>
```