### PR TITLE
update sorted column cells to have colored backgrounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",

--- a/src/components/mutable-element.ts
+++ b/src/components/mutable-element.ts
@@ -210,6 +210,9 @@ export class MutableElement extends ClassifiedElement {
   @property({ attribute: 'is-last-column', type: Boolean })
   public isLastColumn = false
 
+  @property({ attribute: 'is-active', type: Boolean })
+  public isActive = false
+
   public override updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps)
 

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -107,6 +107,9 @@ export default class AstraTable extends ClassifiedElement {
   @property({ attribute: 'addable-columns', type: Boolean })
   public addableColumns = false
 
+  @property({ attribute: 'active-column', type: String })
+  public activeColumn?: string
+
   @state() protected scrollableEl: Ref<ScrollArea> = createRef()
   @state() public rows: Array<RowAsRecord> = []
   @state() public newRows: Array<RowAsRecord> = []
@@ -402,6 +405,7 @@ export default class AstraTable extends ClassifiedElement {
                       ?interactive=${!this.isNonInteractive}
                       ?hide-dirt=${isNew}
                       ?read-only=${this.readonly}
+                      ?is-active=${name === this.activeColumn}
                     >
                     </astra-td>
                   `
@@ -625,6 +629,7 @@ export default class AstraTable extends ClassifiedElement {
                                   ?is-last-column=${idx === this.visibleColumns.length - 1}
                                   ?removable=${true}
                                   ?interactive=${!this.isNonInteractive}
+                                  ?is-active=${name === this.activeColumn}
                                   @column-hidden=${this._onColumnHidden}
                                   @column-removed=${this._onColumnRemoved}
                                   @column-plugin-deactivated=${this._onColumnPluginDeactivated}

--- a/src/components/table/td.ts
+++ b/src/components/table/td.ts
@@ -207,9 +207,11 @@ export class TableData extends MutableElement {
       'px-cell-padding-x py-cell-padding-y': !this.plugin && !this.blank,
       'px-5': this.blank,
       'border-theme-border dark:border-theme-border-dark': true,
-      'bg-theme-cell dark:bg-theme-cell-dark text-theme-cell-text dark:text-theme-cell-text-dark': true,
+      'text-theme-cell-text dark:text-theme-cell-text-dark': true,
+      'bg-theme-cell dark:bg-theme-cell-dark': !this.isActive && (!this.dirty || this.hideDirt),
+      'bg-theme-row-selected dark:bg-theme-row-selected-dark': this.isActive && (!this.dirty || this.hideDirt), // i.e. this is the column being sorted
       'bg-theme-cell-dirty dark:bg-theme-cell-dirty-dark': this.dirty && !this.hideDirt, // dirty cells
-      'group-hover:bg-theme-row-hover dark:group-hover:bg-theme-row-hover-dark': !this.dirty || this.hideDirt,
+      'group-hover:bg-neutral-50 dark:group-hover:bg-neutral-950': !this.dirty || this.hideDirt,
       'focus:shadow-ringlet dark:focus:shadow-ringlet-dark focus:rounded-[4px] focus:ring-1 focus:ring-black dark:focus:ring-neutral-300 focus:outline-none':
         !this.isEditing && this.isInteractive,
       'border-r':

--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -33,7 +33,8 @@ export class TH extends MutableElement {
       'border-b border-theme-border dark:border-theme-border-dark': true,
       'first:border-l border-t': this.outerBorder,
       'px-cell-padding-x py-cell-padding-y': true,
-      'bg-theme-column dark:bg-theme-column-dark': !this.dirty,
+      'bg-theme-column dark:bg-theme-column-dark': !this.dirty && !this.isActive,
+      'bg-theme-row-selected dark:bg-theme-row-selected-dark': !this.dirty && this.isActive, // i.e. this is the column being sorted
       'bg-theme-cell-dirty dark:bg-theme-cell-dirty-dark': this.dirty,
       'select-none': this.hasMenu, // this is really about handling SSR without hydration; TODO use a better flag?
       // prevent double borders


### PR DESCRIPTION
<img width="1392" alt="image" src="https://github.com/outerbase/astra-ui/assets/368767/a53bf93e-8d5e-408e-b82a-092c8466a248">
<img width="1392" alt="image" src="https://github.com/outerbase/astra-ui/assets/368767/8bab7c9d-5689-4ca4-a5cc-4a84bb2bd51b">

I also addressed weird hover states that seemed to be unintentional color blending
Note: this feature quires the attribute `active-column="..."` which is not set on the Astra demo page; you could modify the html or look for the corresponding Dashboard PR