### PR TITLE
prevent editor from glitching out when not focused

### DIFF
--- a/src/components/table/td.ts
+++ b/src/components/table/td.ts
@@ -485,7 +485,7 @@ export class TableData extends MutableElement {
             <astra-td-menu theme=${this.theme} .options=${menuOptions} @menu-selection=${this.onMenuSelection}>
               <span class=${contentWrapperClass}>${cellContents}</span>
               ${this.isDisplayingPluginEditor
-                ? html`<span id="plugin-editor" class="absolute top-8 caret-current cursor-auto">${cellEditorContents}</span>`
+                ? html`<span id="plugin-editor" class="absolute top-8 caret-current cursor-auto z-10">${cellEditorContents}</span>`
                 : null}
             </astra-td-menu>
           </span>`


### PR DESCRIPTION
weirdly it ignores `z-1` while `style="z-index: 1;"` worked, but i thought I'd stick with classes and `z-10`d

the focus ring disappears tho since, yano, it's not focused..

<img width="728" alt="image" src="https://github.com/outerbase/astra-ui/assets/368767/01ce9cd2-677a-4c11-8aef-1ce001bcad85">
