### PR TITLE
prevent triggering editable state when cell is readonly

### DIFF
--- a/src/components/table/td.ts
+++ b/src/components/table/td.ts
@@ -139,18 +139,20 @@ export class TableData extends MutableElement {
     if (isInputTriggering && noMetaKeys && typeIsNotJSON) {
       event.preventDefault()
 
-      // toggle editing mode
-      self.isEditing = true
+      if (!self.readonly) {
+        // toggle editing mode
+        self.isEditing = true
 
-      // replace the contents
-      self.value = event.key
+        // replace the contents
+        self.value = event.key
 
-      // set the cursor input to the end
-      setTimeout(() => {
-        const input = self.shadowRoot?.querySelector('input')
-        input?.focus()
-        input?.setSelectionRange(input.value.length, input.value.length)
-      }, 0)
+        // set the cursor input to the end
+        setTimeout(() => {
+          const input = self.shadowRoot?.querySelector('input')
+          input?.focus()
+          input?.setSelectionRange(input.value.length, input.value.length)
+        }, 0)
+      }
     }
 
     // navigating around the table


### PR DESCRIPTION
If you hide whitespace changes, you'll see this is just
<img width="702" alt="image" src="https://github.com/outerbase/astra-ui/assets/368767/9d8f1b52-282b-4685-92a8-9b79ea539fd1">
