### PR TITLE
adjust class usage to employ proper css vars for row hover & table bg

### DIFF
--- a/src/components/scroll-area.ts
+++ b/src/components/scroll-area.ts
@@ -262,7 +262,8 @@ export default class ScrollArea extends ClassifiedElement {
     }
     const scrollableClasses = {
       'absolute bottom-0 left-0 right-0 top-0': true,
-      'overflow-scroll bg-theme-table dark:bg-theme-table-dark': this.axis === Axis.both,
+      'bg-theme-table dark:bg-theme-table-dark': true,
+      'overflow-scroll': this.axis === Axis.both,
       'overflow-x-scroll overflow-y-hidden': this.axis === Axis.horizontal,
       'overflow-y-scroll overflow-x-hidden': this.axis === Axis.vertical,
     }

--- a/src/components/scroll-area.ts
+++ b/src/components/scroll-area.ts
@@ -262,7 +262,7 @@ export default class ScrollArea extends ClassifiedElement {
     }
     const scrollableClasses = {
       'absolute bottom-0 left-0 right-0 top-0': true,
-      'overflow-scroll': this.axis === Axis.both,
+      'overflow-scroll bg-theme-table dark:bg-theme-table-dark': this.axis === Axis.both,
       'overflow-x-scroll overflow-y-hidden': this.axis === Axis.horizontal,
       'overflow-y-scroll overflow-x-hidden': this.axis === Axis.vertical,
     }

--- a/src/components/table/td.ts
+++ b/src/components/table/td.ts
@@ -217,7 +217,7 @@ export class TableData extends MutableElement {
       'bg-theme-cell dark:bg-theme-cell-dark': !this.isActive && (!this.dirty || this.hideDirt),
       'bg-theme-row-selected dark:bg-theme-row-selected-dark': this.isActive && (!this.dirty || this.hideDirt), // i.e. this is the column being sorted
       'bg-theme-cell-dirty dark:bg-theme-cell-dirty-dark': this.dirty && !this.hideDirt, // dirty cells
-      'group-hover:bg-neutral-50 dark:group-hover:bg-neutral-950': !this.dirty || this.hideDirt,
+      'group-hover:bg-theme-row-hover dark:group-hover:bg-theme-row-hover-dark': !this.dirty || this.hideDirt,
       'focus:shadow-ringlet dark:focus:shadow-ringlet-dark focus:rounded-[4px] focus:ring-1 focus:ring-black dark:focus:ring-neutral-300 focus:outline-none':
         !this.isEditing && this.isInteractive,
       'border-r':


### PR DESCRIPTION
<img width="684" alt="image" src="https://github.com/user-attachments/assets/ed576300-e0ba-4b9f-8ff7-69d57f9cddbe">

screen shot taken with the following page styles specified
```html
<style>
  * {
    --border-color: #293945;
    --text-color: white;

    --table-background-color: green;
    --table-row-even-background-color: #141b21;
    --table-row-odd-background-color: #141b21;
    --table-row-selected-background-color: #252e35;

    --hover-background-color: #252e35;

    --column-header-background-color: #141b21;
    --column-header-text-color: #c5cace;
  }

  [outerbase-table] {
    display: table;
    height: 100%;
    width: 100%;
  }
</style>
```