### PR TITLE
Remove whitespace-pre in td

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.0.23-chart.10",
+  "version": "0.0.23-chart.12",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",

--- a/src/components/table/core/td.ts
+++ b/src/components/table/core/td.ts
@@ -479,7 +479,7 @@ export class TableData extends MutableElement {
             @paste=${this.onPaste}
           >
             <astra-td-menu theme=${this.theme} .options=${menuOptions} @menu-selection=${this.onMenuSelection}>
-              <span class="whitespace-pre ${this.theme === 'dark' ? 'dark' : ''}">${cellContents}</span>
+              <span class="${this.theme === 'dark' ? 'dark' : ''}">${cellContents}</span>
               ${this.isDisplayingPluginEditor
                 ? html`<span id="plugin-editor" class="absolute top-8 caret-current cursor-auto z-10">${cellEditorContents}</span>`
                 : null}


### PR DESCRIPTION
The `whitespace-pre` here did not seem to positively affect anything and had unnoticeable changes in default cells. However, when plugins were utilized it altered how they were laying out their children DOM elements.

I don't think this is required to have here so removing.