### PR TITLE
add illustrative/placeholder button for cell accessory

### DIFF
--- a/src/components/table/core/td.ts
+++ b/src/components/table/core/td.ts
@@ -1,4 +1,4 @@
-import { css, html, type PropertyValueMap, type TemplateResult } from 'lit'
+import { css, html, nothing, type PropertyValueMap, type TemplateResult } from 'lit'
 import type { DirectiveResult } from 'lit/async-directive.js'
 import { customElement, property, state } from 'lit/decorators.js'
 import { createRef, ref, type Ref } from 'lit/directives/ref.js'
@@ -405,7 +405,7 @@ export class TableData extends MutableElement {
 
   public override render() {
     let value = this.value === null ? null : typeof this.value === 'object' ? JSON.stringify(this.value) : this.value
-
+    let pluginAccessory: DirectiveResult<typeof UnsafeHTMLDirective> | typeof nothing = nothing
     if (this.plugin && value && typeof value === 'string') {
       // Replace single, double, and backticks with their HTML entity equivalents
       value = value.replace(/'/g, '&#39;').replace(/"/g, '&quot;').replace(/`/g, '&#96;')
@@ -422,6 +422,13 @@ export class TableData extends MutableElement {
       //      `<${tagName} ${value !== null ? `cellvalue='${value}` : ''} configuration='${config}' ${this.pluginAttributes}></${tagName}>`
       const pluginAsString = unsafeHTML(
         `<${tagName} cellvalue='${value}' columnName='${this.column}'  configuration='${config}' ${this.pluginAttributes}></${tagName}>`
+      )
+
+      pluginAccessory = unsafeHTML(
+        `<${tagName.replace(
+          'outerbase-plugin-cell',
+          'outerbase-plugin-accessory'
+        )} cellvalue='${value}' columnName='${this.column}' configuration='${config}' ${this.pluginAttributes}></${tagName}>`
       )
 
       cellContents = html`${pluginAsString}`
@@ -445,7 +452,7 @@ export class TableData extends MutableElement {
 
     const themeClass = this.theme === 'dark' ? 'dark' : ''
     const inputEl = this.isEditing // &nbsp; prevents the row from collapsing (in height) when there is only 1 column
-      ? html`<div class="${themeClass}">&nbsp;<input .value=${typeof value === 'string' ? value : value ?? ''} ?readonly=${this.readonly} @input=${this.onChange} class="z-[2] absolute top-0 bottom-0 right-0 left-0 bg-theme-table-cell-mutating-background dark:bg-theme-table-cell-mutating-background-dark outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-700 px-3 focus:rounded-[4px]" @blur=${this.onBlur}></input></div>`
+      ? html`<div class="${themeClass}">&nbsp;<input .value=${typeof value === 'string' ? value : (value ?? '')} ?readonly=${this.readonly} @input=${this.onChange} class="z-[2] absolute top-0 bottom-0 right-0 left-0 bg-theme-table-cell-mutating-background dark:bg-theme-table-cell-mutating-background-dark outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-700 px-3 focus:rounded-[4px]" @blur=${this.onBlur}></input></div>`
       : html``
     const emptySlot = this.blank ? html`<slot></slot>` : html``
     const menuOptions = this.dirty
@@ -481,7 +488,7 @@ export class TableData extends MutableElement {
             <astra-td-menu theme=${this.theme} .options=${menuOptions} @menu-selection=${this.onMenuSelection}>
               <div class="flex">
                 <span class="flex-auto truncate whitespace-pre ${this.theme === 'dark' ? 'dark' : ''}">${cellContents}</span>
-                <span class="bg-green-500 px-2 ml-1 rounded">{}</span>
+                ${pluginAccessory}
               </div>
 
               ${this.isDisplayingPluginEditor

--- a/src/components/table/core/td.ts
+++ b/src/components/table/core/td.ts
@@ -479,7 +479,11 @@ export class TableData extends MutableElement {
             @paste=${this.onPaste}
           >
             <astra-td-menu theme=${this.theme} .options=${menuOptions} @menu-selection=${this.onMenuSelection}>
-              <span class="${this.theme === 'dark' ? 'dark' : ''}">${cellContents}</span>
+              <div class="flex">
+                <span class="flex-auto truncate whitespace-pre ${this.theme === 'dark' ? 'dark' : ''}">${cellContents}</span>
+                <span class="bg-green-500 px-2 ml-1 rounded">{}</span>
+              </div>
+
               ${this.isDisplayingPluginEditor
                 ? html`<span id="plugin-editor" class="absolute top-8 caret-current cursor-auto z-10">${cellEditorContents}</span>`
                 : null}


### PR DESCRIPTION
<img width="2560" alt="Screenshot 2024-08-06 at 2 37 22 PM" src="https://github.com/user-attachments/assets/48b75702-7e17-4481-a351-ab2d3afd44d8">

- I explicitly set a value to be a plugin I was manually loading on the page to test/implement this
- I also tested if the tag doesn't exist that it's presence in the mark up doesn't break the existing layout
- I had to disable the width from the CSS contained in the plugin; see all renderings except the one focused in the screen shot