### PR TITLE
remove last border from blank space filler cell

### DIFF
--- a/src/components/table/core/index.ts
+++ b/src/components/table/core/index.ts
@@ -445,6 +445,7 @@ export default class AstraTable extends ClassifiedElement {
                     ?interactive=${false}
                     ?menu=${false}
                     ?blank=${true}
+                    ?is-last-row=${rowIndex === this.rows.length - 1}
                   ></astra-td>`
                 : ''}
             </astra-tr>`

--- a/src/components/table/core/td.ts
+++ b/src/components/table/core/td.ts
@@ -242,7 +242,7 @@ export class TableData extends MutableElement {
         (this.separateCells && this.isLastColumn && this.outerBorder) || // include last column when outerBorder
         (this.separateCells && !this.isLastColumn), // internal cell walls
       'first:border-l': this.separateCells && this.outerBorder, // left/right borders when the `separate-cells` attribute is set
-      'border-b': !this.isLastRow, // bottom border unless last row
+      'border-b': !this.isLastRow || (this.isLastRow && this.outerBorder), // bottom border unless last row
     }
   }
 


### PR DESCRIPTION
This does NOT bring the bottom border back (in Dashboard), but it does ensure the entire last row doesn't have it unless `outer-border` was specified on the table

For Dashboard, I'm thinking maybe we have Dashboard render that bottom row instead, as it's kind of a weird use case that we want the table to only have a bottom border -- it was a bug that it was drawing it even though `outer-border` wasnt specified, and it looks bad specifying it and having the extra top and left borders 🤔 

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/069d9972-b86d-4e75-9777-b8022980c858">