### PR TITLE
prevent unintentional column sorting

### DIFF
--- a/src/components/table/menu/column-menu.ts
+++ b/src/components/table/menu/column-menu.ts
@@ -6,6 +6,26 @@ import { Menu } from './index.js'
 
 @customElement('astra-th-menu')
 export class ColumnMenu extends Menu {
+  onClick(event: MouseEvent) {
+    // prevent the click from surfacing and triggering column sorting
+    event.stopPropagation()
+  }
+
+  constructor() {
+    super()
+    this.onClick = this.onClick.bind(this)
+  }
+
+  public connectedCallback(): void {
+    super.connectedCallback()
+    this.addEventListener('click', this.onClick)
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback()
+    this.removeEventListener('click', this.onClick)
+  }
+
   public override render() {
     return html`
       <div class="flex items-center justify-between gap-2">

--- a/src/components/table/menu/index.ts
+++ b/src/components/table/menu/index.ts
@@ -93,6 +93,9 @@ export class Menu extends ClassifiedElement {
   }
 
   protected onTrigger(event: MouseEvent) {
+    // prevent the click from surfacing and triggering column sorting
+    event.stopPropagation()
+
     this.open = !this.open
     this.activeEvent = event
   }
@@ -112,6 +115,9 @@ export class Menu extends ClassifiedElement {
     const value = parent.getAttribute('data-value')
     if (!value) throw new Error("onItemClick didn't recover a selection value")
     this.onSelection(event, value)
+
+    // close the menu
+    this.open = false
   }
 
   protected onSelection(event: Event, value: string) {


### PR DESCRIPTION
- prevent clicks to the ColumnMenu from bubbling
- prevent clicks to menu items from bubbling
- explicitly close the menu when a selection is made