### PR TITLE
make the editor scroll size smaller

### DIFF
--- a/src/components/astra-editor/index.ts
+++ b/src/components/astra-editor/index.ts
@@ -35,8 +35,8 @@ export class AstraEditor extends LitElement {
   static styles = css`
     .cm-tooltip-autocomplete ul::-webkit-scrollbar,
     .cm-scroller::-webkit-scrollbar {
-      width: 10px;
-      height: 10px;
+      width: 6px;
+      height: 6px;
     }
 
     .cm-scroller::-webkit-scrollbar-thumb {


### PR DESCRIPTION
As I check the scroll size at the sidebar, it use 6px. I will use this size to make it looks consistent.

<img width="444" alt="Screenshot 2024-08-19 at 5 29 16 in the afternoon" src="https://github.com/user-attachments/assets/d5aacb88-a792-4ec5-8f1a-8e3c30c5b3bd">
