### PR TITLE
add `border-b` attribute to include last-row-bottom-border

### DIFF
--- a/src/components/table/core/index.ts
+++ b/src/components/table/core/index.ts
@@ -89,6 +89,9 @@ export default class AstraTable extends ClassifiedElement {
   @property({ attribute: 'outer-border', type: Boolean })
   public outerBorder = false
 
+  @property({ attribute: 'border-b', type: Boolean })
+  public bottomBorder = false
+
   // TODO @johnny make this a Set
   @property({ attribute: 'hidden-columns', type: Array })
   public hiddenColumnNames: Array<string> = []
@@ -370,6 +373,7 @@ export default class AstraTable extends ClassifiedElement {
                     theme=${this.theme}
                     ?separate-cells=${true}
                     ?outer-border=${this.outerBorder}
+                    ?border-b=${this.bottomBorder}
                     ?blank=${true}
                     ?is-last-row=${rowIndex === this.rows.length - 1}
                     ?is-last-column=${false}
@@ -422,6 +426,7 @@ export default class AstraTable extends ClassifiedElement {
                       plugin-attributes=${this.installedPlugins?.[name]?.supportingAttributes ?? ''}
                       ?separate-cells=${true}
                       ?outer-border=${this.outerBorder}
+                      ?border-b=${this.bottomBorder}
                       ?resizable=${!this.staticWidths}
                       ?is-last-row=${rowIndex === this.rows.length - 1}
                       ?is-last-column=${idx === this.visibleColumns.length - 1}
@@ -504,6 +509,7 @@ export default class AstraTable extends ClassifiedElement {
     // measure the height of each row
     const elem = document.createElement('astra-td') as TableData
     elem.outerBorder = this.outerBorder
+    elem.bottomBorder = this.bottomBorder
     elem.isInteractive = true
 
     // Temporarily add to the DOM to measure

--- a/src/components/table/core/td.ts
+++ b/src/components/table/core/td.ts
@@ -242,7 +242,7 @@ export class TableData extends MutableElement {
         (this.separateCells && this.isLastColumn && this.outerBorder) || // include last column when outerBorder
         (this.separateCells && !this.isLastColumn), // internal cell walls
       'first:border-l': this.separateCells && this.outerBorder, // left/right borders when the `separate-cells` attribute is set
-      'border-b': !this.isLastRow || (this.isLastRow && this.outerBorder), // bottom border unless last row
+      'border-b': !this.isLastRow || (this.isLastRow && this.outerBorder) || (this.isLastRow && this.bottomBorder), // bottom border unless last row
     }
   }
 

--- a/src/components/table/mutable-element.ts
+++ b/src/components/table/mutable-element.ts
@@ -181,6 +181,9 @@ export class MutableElement extends ClassifiedElement {
   @property({ attribute: 'outer-border', type: Boolean })
   public outerBorder = false
 
+  @property({ attribute: 'border-b', type: Boolean })
+  public bottomBorder = false
+
   // allows, for example, <astra-td separate-cells="true" />
   @property({ type: Boolean, attribute: 'separate-cells' })
   public separateCells: boolean = false

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -224,7 +224,7 @@ const textData: DashboardV3Chart = {
             schema={{ columns }}
             data={[...rows, ...rows, ...rows, ...rows, ...rows]}
             theme="light"
-            outer-border
+            bottom-border
             theme="dark"
             selectable-rows
             tableName="foo"
@@ -240,7 +240,7 @@ const textData: DashboardV3Chart = {
             schema={{ columns }}
             data={[...rows, ...rows, ...rows, ...rows, ...rows]}
             theme="light"
-            outer-border
+            bottom-border
             theme="light"
             selectable-rows
             tableName="foo"


### PR DESCRIPTION
Add the `border-b` attribute to a table to instruct `<td>` cells to draw their bottom border -- similar to `outer-border`, but only yano, the bottom