### PR TITLE
remove click interceptor

### DIFF
--- a/src/components/table/menu/column-menu.ts
+++ b/src/components/table/menu/column-menu.ts
@@ -6,26 +6,6 @@ import { Menu } from './index.js'
 
 @customElement('astra-th-menu')
 export class ColumnMenu extends Menu {
-  onClick(event: MouseEvent) {
-    // prevent the click from surfacing and triggering column sorting
-    event.stopPropagation()
-  }
-
-  constructor() {
-    super()
-    this.onClick = this.onClick.bind(this)
-  }
-
-  public connectedCallback(): void {
-    super.connectedCallback()
-    this.addEventListener('click', this.onClick)
-  }
-
-  public disconnectedCallback(): void {
-    super.disconnectedCallback()
-    this.removeEventListener('click', this.onClick)
-  }
-
   public override render() {
     return html`
       <div class="flex items-center justify-between gap-2">


### PR DESCRIPTION
I'm not sure why this was added, I'm fairly certain at the time if you chose an item in a menu that it would cause the sort to happen even though you didn't intend for it to ... but after removing this, I can still toggle the menu and choose items without triggering sorting