### PR TITLE
fixed docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <br />
     <a href="https://www.outerbase.com/">Website</a>
     <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-    <a href="https://www.docs.outerbase.com/">Docs</a>
+    <a href="https://docs.outerbase.com/">Docs</a>
     <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
     <a href="https://www.outerbase.com/blog/">Blog</a>
     <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>


### PR DESCRIPTION
www.docs.outerbase.com needs to be docs.outerbase.com, the www prefix dead ends