### PR TITLE
fix keyboard navigation of menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",

--- a/src/components/table/menu/index.ts
+++ b/src/components/table/menu/index.ts
@@ -342,7 +342,7 @@ export class NestedMenu extends ClassifiedElement {
   }
 
   _focusNextItem(direction: 1 | -1) {
-    const itemCount = this.items.length
+    const itemCount = this.items.filter((i) => !i.separator).length // skip separator items
     let newIndex = this.activeIndex !== null ? this.activeIndex + direction : 0
     if (newIndex < 0) newIndex = itemCount - 1
     if (newIndex >= itemCount) newIndex = 0


### PR DESCRIPTION
the separators we're being erroneously included and causing us to call `.focus()` on undefined when going beyond the first/last menu items