### PR TITLE
horizontal virtualized scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",

--- a/src/components/scroll-area.ts
+++ b/src/components/scroll-area.ts
@@ -46,7 +46,8 @@ export default class ScrollArea extends ClassifiedElement {
 
   protected horizontalScrollProgress = 0
   protected verticalScrollProgress = 0
-  protected previousScrollPosition?: number
+  protected previousScrollPositionY?: number
+  protected previousScrollPositionX?: number
 
   private pendingMouseLeave?: number
   private startX = 0
@@ -93,16 +94,20 @@ export default class ScrollArea extends ClassifiedElement {
 
   // trigger `onScroll` when scrolling distance >= threshold (for the sake of optimizing performance)
   private _onScroll(_event: Event) {
-    // const previous = this.previousScrollPosition ?? 0
-    // const current = this.scroller.value?.scrollTop ?? 0
-    // const difference = Math.abs(previous - current)
-    // if (difference > this.threshold) {
-    //   this.previousScrollPosition = current
-    //   if (typeof this.onScroll === 'function') {
-    //     this.onScroll()
-    //   }
-    // }
-    this.onScroll?.()
+    const previousVertical = this.previousScrollPositionY ?? 0
+    const previousHorizontal = this.previousScrollPositionX ?? 0
+    const currentVertical = this.scroller.value?.scrollTop ?? 0
+    const currentHorizontal = this.scroller.value?.scrollLeft ?? 0
+    const differenceVertical = Math.abs(previousVertical - currentVertical)
+    const differenceHorizontal = Math.abs(previousHorizontal - currentHorizontal)
+
+    if (differenceVertical > this.threshold || differenceHorizontal > this.threshold) {
+      this.previousScrollPositionY = currentVertical
+      this.previousScrollPositionX = currentHorizontal
+      if (typeof this.onScroll === 'function') {
+        this.onScroll()
+      }
+    }
   }
 
   protected onClickVerticalScroller(event: MouseEvent) {

--- a/src/components/scroll-area.ts
+++ b/src/components/scroll-area.ts
@@ -93,15 +93,16 @@ export default class ScrollArea extends ClassifiedElement {
 
   // trigger `onScroll` when scrolling distance >= threshold (for the sake of optimizing performance)
   private _onScroll(_event: Event) {
-    const previous = this.previousScrollPosition ?? 0
-    const current = this.scroller.value?.scrollTop ?? 0
-    const difference = Math.abs(previous - current)
-    if (difference > this.threshold) {
-      this.previousScrollPosition = current
-      if (typeof this.onScroll === 'function') {
-        this.onScroll()
-      }
-    }
+    // const previous = this.previousScrollPosition ?? 0
+    // const current = this.scroller.value?.scrollTop ?? 0
+    // const difference = Math.abs(previous - current)
+    // if (difference > this.threshold) {
+    //   this.previousScrollPosition = current
+    //   if (typeof this.onScroll === 'function') {
+    //     this.onScroll()
+    //   }
+    // }
+    this.onScroll?.()
   }
 
   protected onClickVerticalScroller(event: MouseEvent) {

--- a/src/components/table/add-column.ts
+++ b/src/components/table/add-column.ts
@@ -75,7 +75,7 @@ export class AddColumnElement extends ClassifiedElement {
           autocomplete="off"
           .value=${this.columnName}
           @input=${this.onChange}
-        />
+        ></input>
         ${this.errorMessage}
       </div>
 

--- a/src/components/table/check-box.ts
+++ b/src/components/table/check-box.ts
@@ -48,7 +48,7 @@ export class CustomCheckbox extends LitElement {
     return html`
       <div class="flex flex-none items-center cursor-pointer ${this.theme === 'dark' ? 'dark' : ''}" @click="${this.toggleCheckbox}">
         ${this.checked ? CustomCheckbox.checkedTemplate : CustomCheckbox.uncheckedTemplate}
-        <input type="checkbox" ?checked="${this.checked}" @change="${this.toggleCheckbox}" class="hidden" />
+        <input type="checkbox" ?checked="${this.checked}" @change="${this.toggleCheckbox}" class="hidden"></input>
       </div>
     `
   }

--- a/src/components/table/core/index.ts
+++ b/src/components/table/core/index.ts
@@ -159,12 +159,23 @@ export default class AstraTable extends ClassifiedElement {
     )
 
     const scrollContainer = this.scrollableEl?.value?.scroller?.value
-    if (!scrollContainer) return
+    if (!scrollContainer || this.visibleColumns.length === 0) {
+      this.visibleColumnStartIndex = 0
+      this.visibleColumnEndIndex = 0
+      this.leftSpacerWidth = 0
+      this.rightSpacerWidth = 0
+      return
+    }
 
     const scrollLeft = scrollContainer.scrollLeft
     const viewportWidth = scrollContainer.clientWidth
 
-    if (this.visibleColumns.length <= Math.ceil(viewportWidth / this.widthForColumnType(this.visibleColumns[0].name))) {
+    // If all columns fit in the viewport, show them all
+    const totalColumnsWidth = this.visibleColumns.reduce(
+      (sum, column) => sum + this.widthForColumnType(column.name, this.columnWidthOffsets[column.name]),
+      0
+    )
+    if (totalColumnsWidth <= viewportWidth) {
       this.visibleColumnStartIndex = 0
       this.visibleColumnEndIndex = this.visibleColumns.length
       this.leftSpacerWidth = 0

--- a/src/components/table/core/index.ts
+++ b/src/components/table/core/index.ts
@@ -458,7 +458,7 @@ export default class AstraTable extends ClassifiedElement {
                         ?checked="${this.selectedRowUUIDs.has(id)}"
                         @toggle-check="${() => this.toggleSelectedRow(id)}"
                         theme=${this.theme}
-                      />
+                      ></check-box>
                     </div>
                   </astra-td>`
                 : null}
@@ -697,7 +697,7 @@ export default class AstraTable extends ClassifiedElement {
               //   dispatch event that row selection changed
               this._onRowSelection()
             }}
-          />`
+          ></check-box>`
         : ''
 
     return html`<astra-scroll-area

--- a/src/components/table/core/index.ts
+++ b/src/components/table/core/index.ts
@@ -170,6 +170,14 @@ export default class AstraTable extends ClassifiedElement {
     const scrollLeft = scrollContainer.scrollLeft
     const viewportWidth = scrollContainer.clientWidth
 
+    if (this.visibleColumns.length <= Math.ceil(viewportWidth / this.widthForColumnType(this.visibleColumns[0].name))) {
+      this.visibleColumnStartIndex = 0
+      this.visibleColumnEndIndex = this.visibleColumns.length
+      this.leftSpacerWidth = 0
+      this.rightSpacerWidth = 0
+      return
+    }
+
     let accumulatedWidth = 0
     let newStartIndex = 0
     let newEndIndex = 0
@@ -206,7 +214,7 @@ export default class AstraTable extends ClassifiedElement {
     const oldStartIndex = this.visibleColumnStartIndex
     const oldEndIndex = this.visibleColumnEndIndex
     this.visibleColumnStartIndex = Math.max(0, newStartIndex - COLUMN_BUFFER_SIZE)
-    this.visibleColumnEndIndex = Math.min(this.visibleColumns.length - 1, newEndIndex + COLUMN_BUFFER_SIZE)
+    this.visibleColumnEndIndex = Math.min(this.visibleColumns.length, newEndIndex + COLUMN_BUFFER_SIZE)
 
     // Calculate widths
     this.leftSpacerWidth = this.visibleColumns
@@ -443,7 +451,7 @@ export default class AstraTable extends ClassifiedElement {
         return !this.removedRowUUIDs.has(id)
           ? html`<astra-tr .selected=${this.selectedRowUUIDs.has(id)} ?new=${isNew} @on-selection=${this._onRowSelection}>
               ${repeat(
-                this.visibleColumns.slice(this.visibleColumnStartIndex, this.visibleColumnEndIndex),
+                this.visibleColumns.slice(this.visibleColumnStartIndex, this.visibleColumnEndIndex + 1),
                 ({ name }) => name,
                 ({ name }, idx) => {
                   const absoluteIdx = idx + this.visibleColumnStartIndex
@@ -691,7 +699,7 @@ export default class AstraTable extends ClassifiedElement {
               <!-- first column of (optional) checkboxes -->
 
               ${repeat(
-                this.visibleColumns.slice(this.visibleColumnStartIndex, this.visibleColumnEndIndex),
+                this.visibleColumns.slice(this.visibleColumnStartIndex, this.visibleColumnEndIndex + 1),
                 ({ name }, _idx) => name,
                 ({ name }, idx) => {
                   const absoluteIdx = idx + this.visibleColumnStartIndex

--- a/src/components/table/core/index.ts
+++ b/src/components/table/core/index.ts
@@ -144,6 +144,7 @@ export default class AstraTable extends ClassifiedElement {
   @state() protected columnTypes?: Record<string, string | number | boolean | undefined>
   @state() protected rowHeight: number = 38
 
+  // virtualized scrolling
   @state() private _height?: number // TODO remove this?
   @state() private visibleRowEndIndex = 0
   @state() private visibleRowStartIndex = 0
@@ -151,6 +152,9 @@ export default class AstraTable extends ClassifiedElement {
   @state() private visibleColumnEndIndex = 0
   @state() private leftSpacerWidth = 0
   @state() private rightSpacerWidth = 0
+
+  // prevent leaks
+  private rowHeightTimeoutId: number | null = null
 
   protected updateVisibleColumns() {
     this.visibleColumns = this.columns.filter(
@@ -581,7 +585,7 @@ export default class AstraTable extends ClassifiedElement {
 
     // Temporarily add to the DOM to measure
     this.scrollableEl?.value?.appendChild(elem)
-    setTimeout(() => {
+    this.rowHeightTimeoutId = window.setTimeout(() => {
       const offsetHeight = elem.offsetHeight
       this.scrollableEl?.value?.removeChild(elem)
       if (this.rowHeight !== offsetHeight) {
@@ -647,6 +651,9 @@ export default class AstraTable extends ClassifiedElement {
   public override disconnectedCallback() {
     super.disconnectedCallback()
     document.removeEventListener('keydown', this.onKeyDown)
+    if (this.rowHeightTimeoutId !== null) {
+      clearTimeout(this.rowHeightTimeoutId)
+    }
   }
 
   public override render() {

--- a/src/components/table/menu/index.ts
+++ b/src/components/table/menu/index.ts
@@ -94,7 +94,7 @@ export class Menu extends ClassifiedElement {
         this.dispatchEvent(new Event('closed'))
       }}"
       ${ref(this.nestedMenu)}
-    />`
+    ></astra-nested-menu>`
 
     return this.anchored
       ? html`

--- a/src/components/table/outerbase-table.ts
+++ b/src/components/table/outerbase-table.ts
@@ -492,8 +492,8 @@ export default class OuterbaseTable extends AstraTable {
             this.codeEditorValue = detail
           }}
         >
-          <astra-editor-sql dialect="sqlite" schema="{JSON.stringify(SCHEMA)}" />
-          <astra-editor-handlebar variables="variable1,variable2" />
+          <astra-editor-sql dialect="sqlite" schema="{JSON.stringify(SCHEMA)}"></astra-editor-sql>
+          <astra-editor-handlebar variables="variable1,variable2"></astra-editor-handlebar>
         </astra-editor>
       </div>
     `

--- a/src/components/universe/index.ts
+++ b/src/components/universe/index.ts
@@ -141,7 +141,7 @@ export class TextEditor extends ClassifiedElement {
     return html`
       <div id="container" class="font-mono flex flex-row border-4 w-full h-full relative">
         <!-- positions a div immediately following the cursor; useful for, say, a context menu -->
-        <div class="absolute z-10 ml-12" style="top: ${this.cursorY}px; left: ${this.cursorX}px"><slot name="cursor" /></div>
+        <div class="absolute z-10 ml-12" style="top: ${this.cursorY}px; left: ${this.cursorX}px"><slot name="cursor"></slot></div>
 
         <div class="flex flex-none h-full w-full no-scrollbar">
           <!-- line numbers  -->


### PR DESCRIPTION
> Honey, you're gonna love this..

![](https://images.paramount.tech/uri/mgid:arc:imageassetref:shared.southpark.global:a115095e-fb54-46bd-9b77-3dcad8df94cd?quality=0.7&gen=ntrn&format=jpg&width=1200&height=630&crop=true)

Performance is relative to the number of visible cells, therefore the larger your browser window the more degraded it will become.

Chrome, of course, out performs Safari.

We can still go farther, with removing the accessory web components (WCs) from all the cells, and possibly delay any cells being WCs at all until they have focus / interacted with

Or we could just move on, since this is pretty fast before even considering Visal's state preservation change being on top of it. But I think reducing those WCs would improve the scroll smoothness on Safari and Tauri regardless of tab changing performance.