### PR TITLE
v0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",


### PR DESCRIPTION
- attempts to resolve visal's issue with something missing (failed?)
- removes ability to put a checkbox in an editable state
- sets focus on checkbox itself instead of it's cell

https://github.com/outerbase/dashboard.next/pull/1225