### PR TITLE
fixing when prompt placeholder does not disappear

### DIFF
--- a/src/components/astra-editor/plugins/prompt.ts
+++ b/src/components/astra-editor/plugins/prompt.ts
@@ -202,17 +202,18 @@ function createPromptStatePlugin(plugin: AstraEditorPromptPlugin) {
       const cursorPosition = tr.state.selection.main.from
 
       // Try to remove the prompt widget if we change the cursor position
+      const line = tr.state.doc.lineAt(cursorPosition).text
+
       v = v.update({
         filter: (from, _, d) => {
           if (d === decorationPreviewLine) return true
-          promptWidgetFound = promptWidgetFound || from === cursorPosition
+          promptWidgetFound = (promptWidgetFound || from === cursorPosition) && line === ''
           return from === cursorPosition
         },
       })
 
       if (promptWidgetFound) return v
 
-      const line = tr.state.doc.lineAt(cursorPosition).text
       if (line !== '') return Decoration.none
 
       // If line is empty, we just show the prompt placeholder

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ declare global {
         value?: string
         placeholder?: string
         theme?: string
+        readonly?: boolean
       }
       'astra-editor-sql': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & { dialect?: string; schema?: string }
       'astra-editor-javascript': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & { typescript?: boolean }


### PR DESCRIPTION
- Fixing when prompt placeholder does not disappear if user change the value programmatically.
- Add readonly to the typescript

<img width="714" alt="Screenshot 2024-09-24 at 9 47 53 in the morning" src="https://github.com/user-attachments/assets/ed353904-68b4-43ee-b0fb-5cb8d62dd887">
