### PR TITLE
add logandust theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outerbase/astra-ui",
-  "version": "0.5.8",
+  "version": "0.5.10",
   "type": "module",
   "main": "dist/js/index.js",
   "module": "dist/js/index.js",

--- a/src/components/astra-editor/theme.ts
+++ b/src/components/astra-editor/theme.ts
@@ -10,6 +10,7 @@ interface ThemeSetting {
   gutterBackground?: string
   gutterForeground?: string
   gutterActiveForeground?: string
+  gutterActiveBackground?: string
   gutterBorder?: string
   lineHighlight?: string
   selection?: string
@@ -65,6 +66,8 @@ function createCodeMirrorTheme(styles: TagStyle[], settings: ThemeSetting): Exte
 
   if (settings.gutterActiveForeground) {
     themeStyles['.cm-activeLineGutter'].color = settings.gutterActiveForeground
+    themeStyles['.cm-activeLineGutter'].backgroundColor =
+      settings.gutterActiveBackground ?? themeStyles['.cm-activeLineGutter'].backgroundColor // preserve
   }
 
   const themeExtension = EditorView.theme(themeStyles, {
@@ -120,6 +123,60 @@ function createMoondustTheme(theme: 'dark' | 'light'): Extension {
         gutterForeground: '#737373',
         gutterBackground: '#0A0A0A',
         gutterActiveForeground: '#fff',
+        gutterBorder: 'transparent',
+      }
+    )
+  }
+}
+
+function createLogandustTheme(theme: 'dark' | 'light'): Extension {
+  if (theme === 'light') {
+    return createCodeMirrorTheme(
+      [
+        { tag: [t.keyword, t.typeName, t.standard(t.name)], color: '#737373' },
+        { tag: [t.string], color: '#737373' },
+        {
+          tag: [t.number],
+          color: 'indigo',
+        },
+        { tag: [t.operator, t.operatorKeyword], color: 'indigo' },
+        { tag: [t.lineComment, t.blockComment, t.comment], color: '#737373' },
+        { tag: [t.null, t.bool], color: '#111111' },
+      ],
+      {
+        theme,
+        foreground: '#111111',
+        selection: '#ccc',
+        lineHighlight: '#eee',
+        gutterForeground: '#737373',
+        gutterBackground: 'transparent',
+        gutterActiveForeground: '#000',
+        gutterActiveBackground: 'transparent',
+        gutterBorder: 'transparent',
+      }
+    )
+  } else {
+    return createCodeMirrorTheme(
+      [
+        { tag: [t.keyword, t.typeName, t.standard(t.name)], color: 'white' },
+        { tag: [t.string], color: '#9ca3af' },
+        {
+          tag: [t.number],
+          color: '#8be9fd',
+        },
+        { tag: [t.operator, t.operatorKeyword], color: 'white' },
+        { tag: [t.lineComment, t.blockComment, t.comment], color: '#737373' },
+        { tag: [t.null, t.bool], color: 'white' },
+      ],
+      {
+        theme,
+        foreground: '#9ca3af',
+        selection: '#333',
+        lineHighlight: '#151515',
+        gutterForeground: '#737373',
+        gutterBackground: 'transparent',
+        gutterActiveForeground: '#fff',
+        gutterActiveBackground: 'transparent',
         gutterBorder: 'transparent',
       }
     )
@@ -233,5 +290,6 @@ function createFreedomTheme(theme: 'dark' | 'light'): Extension {
 export function getPredefineTheme(color: 'dark' | 'light', themeName: string) {
   if (themeName === 'invasion') return createInvasionTheme(color)
   if (themeName === 'freedom') return createFreedomTheme(color)
+  if (themeName === 'logandust') return createLogandustTheme(color)
   return createMoondustTheme(color)
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/70b488a1-6787-4873-9af6-ad9444a8696a)

![](https://amphetamem.es/meme?id=the-simpsons_08_23_466&timestamp=0%3A19%3A47.165&text=Well%2C+basically%2C%0AI+just+copied+the+moondust+theme+we+have+now.&dimensions=1440x1080&title=&year=&series=The+Simpsons&season=8&episodeNumber=23&episodeTitle=Homer%27s+Enemy&tsv=%27basically%27%3A2A+%27copied%27%3A5A+%27have%27%3A9A+%27i%27%3A3A+%27just%27%3A4A+%27now%27%3A10A+%27plant%27%3A7A+%27simpsons%27%3A12B+%27the%27%3A6A%2C11B+%27we%27%3A8A+%27well%27%3A1A&at=%2Fthe-simpsons%2F08%2F23%2F0-19-47-165&text_corrected=)

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/87130ca2-bb0a-44ee-8f70-efa52ba0c766">
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/9b3428e8-95b3-4d49-8b53-90010cb2481a">